### PR TITLE
ci(.npmrc): add .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}


### PR DESCRIPTION
CI release is failing because of no token, even though the secret is brought in the repository
